### PR TITLE
Refactor to structure more like typical areaDetector driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ data
 documentation
 lib
 .svn*
-iocs/*IOC*
-iocs/example
 .idea
+auto_settings.sav*
+envPaths

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ TOP = .
 include $(TOP)/configure/CONFIG
 DIRS := $(DIRS) $(filter-out $(DIRS), configure)
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
-DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocBoot))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocs))
 
 define DIR_template
  $(1)_DEPEND_DIRS = configure
 endef
 $(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
 
-iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
+iocs_DEPEND_DIRS += $(filter %App,$(DIRS))
 
 # Comment out the following lines to disable creation of example iocs and documentation
 #DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard etc))
@@ -26,3 +26,13 @@ iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 include $(TOP)/configure/RULES_TOP
 
 
+
+uninstall: uninstall_iocs
+uninstall_iocs:
+	$(MAKE) -C iocs uninstall
+.PHONY: uninstall uninstall_iocs
+
+realuninstall: realuninstall_iocs
+realuninstall_iocs:
+	$(MAKE) -C iocs realuninstall
+.PHONY: realuninstall realuninstall_iocs

--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -15,7 +15,6 @@ endif
 
 CONFIG = $(RULES)/configure
 include $(CONFIG)/CONFIG
--include $(CONFIG)/CONFIG.Dls
 
 # Override the Base definition:
 INSTALL_LOCATION = $(TOP)

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS = 
+#CROSS_COMPILER_TARGET_ARCHS = 
 
 # To install files into a location other than $(TOP) define
 #   INSTALL_LOCATION here.
@@ -31,3 +31,14 @@ CROSS_COMPILER_TARGET_ARCHS =
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+
+# Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH)
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.Common.$(T_A)
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/iocs/Makefile
+++ b/iocs/Makefile
@@ -1,0 +1,24 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+
+DIRS := $(wildcard *IOC)
+
+include $(TOP)/configure/RULES_TOP
+
+uninstallTargets = $(foreach dir, $(DIRS), $(dir)$(DIVIDER)uninstall)
+uninstall: $(uninstallTargets)
+define UNINSTALL_template
+$(1)$(DIVIDER)uninstall:
+	$(MAKE) -C $(1) uninstall
+endef
+$(foreach dir, $(DIRS), $(eval $(call UNINSTALL_template,$(dir))))
+.PHONY: uninstall $(uninstallTargets)
+
+realuninstallTargets = $(foreach dir, $(DIRS), $(dir)$(DIVIDER)realuninstall)
+realuninstall: $(realuninstallTargets)
+define REALUNINSTALL_template
+$(1)$(DIVIDER)realuninstall:
+	$(MAKE) -C $(1) realuninstall
+endef
+$(foreach dir, $(DIRS), $(eval $(call REALUNINSTALL_template,$(dir))))
+.PHONY: realuninstall $(realuninstallTargets)

--- a/iocs/miroIOC/Makefile
+++ b/iocs/miroIOC/Makefile
@@ -1,0 +1,8 @@
+#Makefile at top of application tree
+TOP = .
+include $(TOP)/configure/CONFIG
+DIRS := $(DIRS) $(filter-out $(DIRS), configure)
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *app))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocBoot))
+include $(TOP)/configure/RULES_TOP

--- a/iocs/miroIOC/configure/CONFIG
+++ b/iocs/miroIOC/configure/CONFIG
@@ -1,0 +1,29 @@
+# CONFIG - Load build configuration data
+#
+# Do not make changes to this file!
+
+# Allow user to override where the build rules come from
+RULES = $(EPICS_BASE)
+
+# RELEASE files point to other application tops
+include $(TOP)/configure/RELEASE
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+-include $(TOP)/configure/RELEASE.Common.$(T_A)
+-include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+CONFIG = $(RULES)/configure
+include $(CONFIG)/CONFIG
+
+# Override the Base definition:
+INSTALL_LOCATION = $(TOP)
+
+# CONFIG_SITE files contain other build configuration settings
+include $(TOP)/configure/CONFIG_SITE
+-include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+ -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+ -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+

--- a/iocs/miroIOC/configure/CONFIG_SITE
+++ b/iocs/miroIOC/configure/CONFIG_SITE
@@ -1,0 +1,42 @@
+# CONFIG_SITE
+
+# Make any application-specific changes to the EPICS build
+#   configuration variables in this file.
+#
+# Host/target specific settings can be specified in files named
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+#   CONFIG_SITE.Common.$(T_A)
+#   CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+
+# CHECK_RELEASE controls the consistency checking of the support
+#   applications pointed to by the RELEASE* files.
+# Normally CHECK_RELEASE should be set to YES.
+# Set CHECK_RELEASE to NO to disable checking completely.
+# Set CHECK_RELEASE to WARN to perform consistency checking but
+#   continue building anyway if conflicts are found.
+CHECK_RELEASE = YES
+
+# Set this when you only want to compile this application
+#   for a subset of the cross-compiled target architectures
+#   that Base is built for.
+#CROSS_COMPILER_TARGET_ARCHS = vxWorks-68040
+
+# To install files into a location other than $(TOP) define
+#   INSTALL_LOCATION here.
+#INSTALL_LOCATION=</path/name/to/install/top>
+
+# Set this when your IOC and the host use different paths
+#   to access the application. This will be needed to boot
+#   from a Microsoft FTP server or with some NFS mounts.
+# You must rebuild in the iocBoot directory for this to
+#   take effect.
+#IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+# Get settings from AREA_DETECTOR, so we only have to configure once for all detectors if we want to
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH)
+-include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+ifdef T_A
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.Common.$(T_A)
+  -include $(AREA_DETECTOR)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif

--- a/iocs/miroIOC/configure/CONFIG_SITE.Common.linux-x86
+++ b/iocs/miroIOC/configure/CONFIG_SITE.Common.linux-x86
@@ -1,0 +1,6 @@
+# There is a problem when building dynamically on our linux-x86 system, due to functions called in PvAPI.a.
+
+# These can be fixed either by building statically with this line:
+#STATIC_BUILD=YES
+# Or by building dynamically with this line:
+PROD_SYS_LIBS += pthread rt

--- a/iocs/miroIOC/configure/Makefile
+++ b/iocs/miroIOC/configure/Makefile
@@ -1,0 +1,9 @@
+
+TOP=..
+
+include $(TOP)/configure/CONFIG
+
+TARGETS = $(CONFIG_TARGETS)
+CONFIGS += $(subst ../,,$(wildcard $(CONFIG_INSTALLS)))
+
+include $(TOP)/configure/RULES

--- a/iocs/miroIOC/configure/RELEASE
+++ b/iocs/miroIOC/configure/RELEASE
@@ -1,0 +1,10 @@
+
+#RELEASE Location of external products
+# Run "gnumake clean uninstall install" in the application
+# top directory each time this file is changed.
+
+MIROCAMERA=$(AREA_DETECTOR)/miroCamera
+
+-include $(TOP)/../../../configure/RELEASE_PRODS_INCLUDE
+-include $(TOP)/RELEASE.local
+-include $(TOP)/configure/RELEASE.local

--- a/iocs/miroIOC/configure/RULES
+++ b/iocs/miroIOC/configure/RULES
@@ -1,0 +1,7 @@
+
+# RULES
+
+include $(CONFIG)/RULES
+
+# Library should be rebuilt because LIBOBJS may have changed
+$(LIBNAME): ../Makefile

--- a/iocs/miroIOC/configure/RULES.ioc
+++ b/iocs/miroIOC/configure/RULES.ioc
@@ -1,0 +1,2 @@
+#RULES.ioc
+include $(CONFIG)/RULES.ioc

--- a/iocs/miroIOC/configure/RULES_DIRS
+++ b/iocs/miroIOC/configure/RULES_DIRS
@@ -1,0 +1,2 @@
+#RULES_DIRS
+include $(CONFIG)/RULES_DIRS

--- a/iocs/miroIOC/configure/RULES_TOP
+++ b/iocs/miroIOC/configure/RULES_TOP
@@ -1,0 +1,2 @@
+#RULES_TOP
+include $(CONFIG)/RULES_TOP

--- a/iocs/miroIOC/iocBoot/Makefile
+++ b/iocs/miroIOC/iocBoot/Makefile
@@ -1,0 +1,5 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+DIRS += $(wildcard *ioc*)
+DIRS += $(wildcard as*)
+include $(EPICS_BASE)/configure/RULES_DIRS

--- a/iocs/miroIOC/iocBoot/iocMIRO/Makefile
+++ b/iocs/miroIOC/iocBoot/iocMIRO/Makefile
@@ -1,0 +1,10 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+#ARCH = win32-x86
+#ARCH = win32-x86-debug
+#ARCH = windows-x64
+#ARCH = windows-x64-debug
+ARCH = linux-x86_64
+#ARCH = linux-x86_64-debug
+TARGETS = envPaths
+include $(TOP)/configure/RULES.ioc

--- a/iocs/miroIOC/iocBoot/iocMIRO/auto_settings.req
+++ b/iocs/miroIOC/iocBoot/iocMIRO/auto_settings.req
@@ -1,0 +1,4 @@
+file "ADBase_settings.req",          P=$(P),  R=cam1:
+file "NDStdArrays_settings.req",    P=$(P),  R=image1:
+file "commonPlugin_settings.req",   P=$(P)
+

--- a/iocs/miroIOC/iocBoot/iocMIRO/autosave/README
+++ b/iocs/miroIOC/iocBoot/iocMIRO/autosave/README
@@ -1,0 +1,1 @@
+Folder that allows for IOC autosave functionality

--- a/iocs/miroIOC/iocBoot/iocMIRO/st.cmd
+++ b/iocs/miroIOC/iocBoot/iocMIRO/st.cmd
@@ -1,0 +1,89 @@
+#!../../bin/linux-x86_64/miroApp
+
+errlogInit(20000)
+
+epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES",  64000000)
+epicsEnvSet("EPICS_CA_AUTO_ADDR_LIST",   "NO")
+epicsEnvSet("EPICS_CA_ADDR_LIST",        "127.0.0.255")
+epicsEnvSet("EPICS_CAS_INTF_ADDR_LIST",  "127.0.0.1")
+
+< envPaths
+#epicsThreadSleep(20)
+dbLoadDatabase("$(TOP)/dbd/miroApp.dbd")
+miroApp_registerRecordDeviceDriver(pdbbase) 
+
+# Prefix for all records
+epicsEnvSet("PREFIX", "DEV:VEO1:")
+# The port name for the detector
+epicsEnvSet("PORT",   "VEO1")
+# The queue size for all plugins
+epicsEnvSet("QSIZE",  "20")
+# The maximim image width; used for row profiles in the NDPluginStats plugin
+epicsEnvSet("XSIZE",  "1280")
+# The maximim image height; used for column profiles in the NDPluginStats plugin
+epicsEnvSet("YSIZE",  "960")
+# The maximum number of time seried points in the NDPluginStats plugin
+epicsEnvSet("NCHANS", "2048")
+# The maximum number of frames buffered in the NDPluginCircularBuff plugin
+epicsEnvSet("CBUFFS", "500")
+# The search path for database files
+epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db")
+# Size of data allowed 
+epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES", 20000000)
+#epicsThreadSleep(15)
+
+
+# Configure control and data TCP/IP socket connections. Default ports should be 7115 and 7116 respectively.
+drvAsynIPPortConfigure("CTRL", "100.100.214.107:7115", 100, 0, 0)
+drvAsynIPPortConfigure("DATA", "100.100.214.107:7116", 100, 0, 0)
+
+# Configure the camera
+miroCameraConfig("$(PORT)", "CTRL", "DATA", 0, 0, 0, 0)
+
+# Enable debugging for certain functions
+#miroCameraDebug("$(PORT)", "readoutDataStream", 1);
+
+asynSetTraceIOMask($(PORT), 0, 2)
+#asynSetTraceMask($(PORT), 0, 0xff)
+
+# Load base camera records
+dbLoadRecords("$(MIROCAMERA)/db/miroCamera.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
+
+# Load a template for each configured cine
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=1, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=2, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=3, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=4, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=5, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=6, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=7, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=8, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=9, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=10:, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=11, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=12, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=13, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=14, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=15, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(MIROCAMERA)/db/miroCine.template", "P=$(PREFIX),R=cam1:, CINE=16, PORT=$(PORT),ADDR=0,TIMEOUT=1")
+
+
+#
+# Create a standard arrays plugin, set it to get data from Driver.
+# int NDStdArraysConfigure(const char *portName, int queueSize, int blockingCallbacks, const char *NDArrayPort, int NDArrayAddr, int maxBuffers, size_t maxMemory,
+#                          int priority, int stackSize, int maxThreads)
+NDStdArraysConfigure("Image1", 3, 0, "$(PORT)", 0)
+dbLoadRecords("$(ADCORE)/db/NDStdArrays.template", "P=$(PREFIX),R=image1:,PORT=Image1,ADDR=0,NDARRAY_PORT=$(PORT),TIMEOUT=1,TYPE=Int16,FTVL=SHORT,NELEMENTS=6000000")
+
+#
+# Load all other plugins using commonPlugins.cmd
+< $(ADCORE)/iocBoot/commonPlugins.cmd
+
+set_requestfile_path("$(MIROCAMERA)/db")
+
+#asynSetTraceMask($(PORT),0,0x09)
+#asynSetTraceMask($(PORT),0,0x11)
+iocInit()
+
+# save things every thirty seconds
+create_monitor_set("auto_settings.req", 30, "P=$(PREFIX)")

--- a/iocs/miroIOC/miroApp/Makefile
+++ b/iocs/miroIOC/miroApp/Makefile
@@ -1,0 +1,8 @@
+TOP = ..
+include $(TOP)/configure/CONFIG
+
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *Db*))
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *src*))
+
+include $(TOP)/configure/RULES_DIRS

--- a/iocs/miroIOC/miroApp/src/Makefile
+++ b/iocs/miroIOC/miroApp/src/Makefile
@@ -1,0 +1,28 @@
+TOP=../..
+include $(TOP)/configure/CONFIG
+#----------------------------------------
+#  ADD MACRO DEFINITIONS AFTER THIS LINE
+
+PROD_NAME = miroApp
+PROD_IOC += $(PROD_NAME)
+
+# <name>.dbd will be created from <name>Include.dbd
+DBD += $(PROD_NAME).dbd
+$(PROD_NAME)_DBD += miroCameraSupport.dbd
+$(PROD_NAME)_DBD += drvAsynIPPort.dbd
+
+# <name>_registerRecordDeviceDriver.cpp will be created from <name>.dbd
+$(PROD_NAME)_SRCS += $(PROD_NAME)_registerRecordDeviceDriver.cpp $(PROD_NAME)Main.cpp
+
+# Add locally compiled object code
+$(PROD_NAME)_LIBS += miro
+
+
+include $(ADCORE)/ADApp/commonDriverMakefile
+
+#=============================
+
+include $(TOP)/configure/RULES
+#----------------------------------------
+#  ADD RULES AFTER THIS LINE
+

--- a/iocs/miroIOC/miroApp/src/miroAppMain.cpp
+++ b/iocs/miroIOC/miroApp/src/miroAppMain.cpp
@@ -1,0 +1,23 @@
+/* exampleMain.cpp */
+/* Author:  Marty Kraimer Date:    17MAR2000 */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "epicsExit.h"
+#include "epicsThread.h"
+#include "iocsh.h"
+
+int main(int argc,char *argv[])
+{
+    if(argc>=2) {
+        iocsh(argv[1]);
+        epicsThreadSleep(.2);
+    }
+    iocsh(NULL);
+    epicsExit(0);
+    return(0);
+}

--- a/miroCameraApp/src/Makefile
+++ b/miroCameraApp/src/Makefile
@@ -7,27 +7,23 @@ include $(TOP)/configure/CONFIG
 # -------------------------------
 
 LIBRARY_IOC += miro
-PROD += createParamIncludes
+#PROD += createParamIncludes
 
 DBD += miroCameraSupport.dbd
 
 # The following are compiled and added to the support library
 HDEPENDS = YES
 
-createParamIncludes_SRCS += createParamIncludes.cpp
-createParamIncludes_SRCS += miroCameraSupport.cpp
+#createParamIncludes_SRCS += createParamIncludes.cpp
+#createParamIncludes_SRCS += miroCameraSupport.cpp
 
 miro_SRCS += MiroCamera.cpp
 miro_SRCS += miroCameraSupport.cpp
 
-miro_LIBS += asyn
-miro_LIBS += ADBase
-miro_LIBS += busy
 
 DATA += miro_hdf5.xml
 
 # We need to link against the EPICS Base libraries
-miro_LIBS += $(EPICS_BASE_IOC_LIBS)
-
+include $(ADCORE)/ADApp/commonLibraryMakefile
 
 include $(TOP)/configure/RULES


### PR DESCRIPTION
Some changes that should simplify out-of-the-box operation. Modifications to the build system to build under `areaDetector` like most other drivers, and also added an example IOC application that is built as part of the process as well.

With these changes getting started should be as simple as cloning under `areaDetector` and running `make`.